### PR TITLE
Code: "Enegry" -> "Energy"

### DIFF
--- a/AMDRyzenCPUPowerManagement/AMDRyzenCPUPMUserClient.cpp
+++ b/AMDRyzenCPUPowerManagement/AMDRyzenCPUPMUserClient.cpp
@@ -160,7 +160,7 @@ IOReturn AMDRyzenCPUPMUserClient::externalMethod(uint32_t selector, IOExternalMe
 
             float *dataOut = (float*) arguments->structureOutput;
             
-            dataOut[0] = (float)fProvider->uniPackageEnegry;
+            dataOut[0] = (float)fProvider->uniPackageEnergy;
             dataOut[1] = fProvider->PACKAGE_TEMPERATURE_perPackage[0];
             dataOut[2] = fProvider->PStateCtl;
             

--- a/AMDRyzenCPUPowerManagement/AMDRyzenCPUPowerManagement.cpp
+++ b/AMDRyzenCPUPowerManagement/AMDRyzenCPUPowerManagement.cpp
@@ -160,9 +160,9 @@ bool AMDRyzenCPUPowerManagement::start(IOService *provider){
         panic("AMDCPUSupport: unable to read power unit\n");
     
     pwrTimeUnit = pow((double)0.5, (double)((rapl >> 16) & 0xf));
-    pwrEnegryUnit = pow((double)0.5, (double)((rapl >> 8) & 0x1f));
+    pwrEnergyUnit = pow((double)0.5, (double)((rapl >> 8) & 0x1f));
     IOLog("a %lld\n", (long long)(pwrTimeUnit * 10000000000));
-    IOLog("b %lld\n", (long long)(pwrEnegryUnit * 10000000000));
+    IOLog("b %lld\n", (long long)(pwrEnergyUnit * 10000000000));
     
     fetchOEMBaseBoardInfo();
     
@@ -578,18 +578,18 @@ void AMDRyzenCPUPowerManagement::updatePackageEnergy(){
     uint64_t msr_value_buf = 0;
     read_msr(kMSR_PKG_ENERGY_STAT, &msr_value_buf);
 
-    uint32_t enegryValue = (uint32_t)(msr_value_buf & 0xffffffff);
+    uint32_t energyValue = (uint32_t)(msr_value_buf & 0xffffffff);
 
-    uint64_t enegryDelta = (lastUpdateEnergyValue <= enegryValue) ?
-    enegryValue - lastUpdateEnergyValue : UINT32_MAX - lastUpdateEnergyValue;
+    uint64_t energyDelta = (lastUpdateEnergyValue <= energyValue) ?
+    energyValue - lastUpdateEnergyValue : UINT32_MAX - lastUpdateEnergyValue;
 
     double seconds = (ctsc - pwrLastTSC) / (double)(xnuTSCFreq);
-    double e = (pwrEnegryUnit * enegryDelta) / (seconds);
+    double e = (pwrEnergyUnit * energyDelta) / (seconds);
     e *= pwrTimeUnit * 1000;
-    uniPackageEnegry = e;
+    uniPackageEnergy = e;
 
 
-    lastUpdateEnergyValue = enegryValue;
+    lastUpdateEnergyValue = energyValue;
     pwrLastTSC = rdtsc64();
 }
 

--- a/AMDRyzenCPUPowerManagement/AMDRyzenCPUPowerManagement.hpp
+++ b/AMDRyzenCPUPowerManagement/AMDRyzenCPUPowerManagement.hpp
@@ -200,7 +200,7 @@ public:
     uint64_t lastUpdateTime;
     uint64_t lastUpdateEnergyValue;
     
-    double uniPackageEnegry;
+    double uniPackageEnergy;
     
     bool disablePrivilegeCheck = false;
 
@@ -224,7 +224,7 @@ private:
     
     float tempOffset = 0;
     double pwrTimeUnit = 0;
-    double pwrEnegryUnit = 0;
+    double pwrEnergyUnit = 0;
     uint64_t pwrLastTSC = 0;
     
     uint64_t xnuTSCFreq = 1;

--- a/SMCAMDProcessor/KeyImplementations.hpp
+++ b/SMCAMDProcessor/KeyImplementations.hpp
@@ -32,7 +32,7 @@ public:
 class TempPackage : public AMDSupportVsmcValue { using AMDSupportVsmcValue::AMDSupportVsmcValue; protected: SMC_RESULT readAccess() override; };
 class TempCore    : public AMDSupportVsmcValue { using AMDSupportVsmcValue::AMDSupportVsmcValue; protected: SMC_RESULT readAccess() override; };
 
-class EnegryPackage: public AMDSupportVsmcValue
+class EnergyPackage: public AMDSupportVsmcValue
 { using AMDSupportVsmcValue::AMDSupportVsmcValue; protected: SMC_RESULT readAccess() override; };
 
 #endif /* KeyImplementations_hpp */

--- a/SMCAMDProcessor/Keyimplementations.cpp
+++ b/SMCAMDProcessor/Keyimplementations.cpp
@@ -23,11 +23,11 @@ SMC_RESULT TempCore::readAccess() {
     return SmcSuccess;
 }
 
-SMC_RESULT EnegryPackage::readAccess(){
+SMC_RESULT EnergyPackage::readAccess(){
     if (type == SmcKeyTypeFloat)
-        *reinterpret_cast<uint32_t *>(data) = VirtualSMCAPI::encodeFlt(provider->uniPackageEnegry);
+        *reinterpret_cast<uint32_t *>(data) = VirtualSMCAPI::encodeFlt(provider->uniPackageEnergy);
     else
-        *reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeSp(type, provider->uniPackageEnegry);
+        *reinterpret_cast<uint16_t *>(data) = VirtualSMCAPI::encodeSp(type, provider->uniPackageEnergy);
     
     return SmcSuccess;
 }

--- a/SMCAMDProcessor/SMCAMDProcessor.cpp
+++ b/SMCAMDProcessor/SMCAMDProcessor.cpp
@@ -25,21 +25,21 @@ bool SMCAMDProcessor::setupKeysVsmc(){
     suc &= VirtualSMCAPI::addKey(KeyTCxp(0), vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp78, new TempPackage(fProvider, 0)));
     
     
-    suc &= VirtualSMCAPI::addKey(KeyPCPR, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnegryPackage(fProvider, 0)));
-    suc &= VirtualSMCAPI::addKey(KeyPSTR, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnegryPackage(fProvider, 0)));
-    //    suc &= VirtualSMCAPI::addKey(KeyPCPT, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnegryPackage(this, 0)));
-    //    suc &= VirtualSMCAPI::addKey(KeyPCTR, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnegryPackage(this, 0)));
+    suc &= VirtualSMCAPI::addKey(KeyPCPR, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnergyPackage(fProvider, 0)));
+    suc &= VirtualSMCAPI::addKey(KeyPSTR, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnergyPackage(fProvider, 0)));
+    //    suc &= VirtualSMCAPI::addKey(KeyPCPT, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnergyPackage(this, 0)));
+    //    suc &= VirtualSMCAPI::addKey(KeyPCTR, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnergyPackage(this, 0)));
     
     
-    //    VirtualSMCAPI::addKey(KeyPC0C, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnegryPackage(this, 0)));
-    //    VirtualSMCAPI::addKey(KeyPC0R, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnegryPackage(this, 0)));
-    //    VirtualSMCAPI::addKey(KeyPCAM, vsmcPlugin.data, VirtualSMCAPI::valueWithFlt(0, new EnegryPackage(this, 0)));
-    //    VirtualSMCAPI::addKey(KeyPCPC, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnegryPackage(this, 0)));
+    //    VirtualSMCAPI::addKey(KeyPC0C, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnergyPackage(this, 0)));
+    //    VirtualSMCAPI::addKey(KeyPC0R, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnergyPackage(this, 0)));
+    //    VirtualSMCAPI::addKey(KeyPCAM, vsmcPlugin.data, VirtualSMCAPI::valueWithFlt(0, new EnergyPackage(this, 0)));
+    //    VirtualSMCAPI::addKey(KeyPCPC, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnergyPackage(this, 0)));
     //
-    //    VirtualSMCAPI::addKey(KeyPC0G, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnegryPackage(this, 0)));
-    //    VirtualSMCAPI::addKey(KeyPCGC, vsmcPlugin.data, VirtualSMCAPI::valueWithFlt(0, new EnegryPackage(this, 0)));
-    //    VirtualSMCAPI::addKey(KeyPCGM, vsmcPlugin.data, VirtualSMCAPI::valueWithFlt(0, new EnegryPackage(this, 0)));
-    //    VirtualSMCAPI::addKey(KeyPCPG, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnegryPackage(this, 0)));
+    //    VirtualSMCAPI::addKey(KeyPC0G, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnergyPackage(this, 0)));
+    //    VirtualSMCAPI::addKey(KeyPCGC, vsmcPlugin.data, VirtualSMCAPI::valueWithFlt(0, new EnergyPackage(this, 0)));
+    //    VirtualSMCAPI::addKey(KeyPCGM, vsmcPlugin.data, VirtualSMCAPI::valueWithFlt(0, new EnergyPackage(this, 0)));
+    //    VirtualSMCAPI::addKey(KeyPCPG, vsmcPlugin.data, VirtualSMCAPI::valueWithSp(0, SmcKeyTypeSp96, new EnergyPackage(this, 0)));
     
     //Since AMD cpu dont have temperature MSR for each core, we simply report the same package temperature for all cores.
     //    for(int core = 0; core < totalNumberOfPhysicalCores; core++){


### PR DESCRIPTION
Fixes spelling of "energy" in the code.

![Screen Shot 2020-04-18 at 1 04 46 PM](https://user-images.githubusercontent.com/1004637/79668894-2e875800-8175-11ea-9e5c-c783768aa2bd.png)
As I don't have VirtualSMCSDK, I haven't compiled to verify that this works, but it _should_ work.