### PR TITLE
Simplifies graph view

### DIFF
--- a/AMD Power Gadget/GraphView.swift
+++ b/AMD Power Gadget/GraphView.swift
@@ -37,7 +37,7 @@ class GraphView: NSView {
     var viewBottom : CGFloat = 0;
     var viewHeight : CGFloat = 100;
     
-    let gridDivLines: [Double] = [0, 0.2, 0.4, 0.6, 0.8, 1]
+    let gridDivLines: [Double] = [0, 0.18, 0.38, 0.68, 1]
     let maxDataPoints = 30
     
     let dummyData: [Double] = [1,3,2]

--- a/AMD Power Gadget/GraphView.swift
+++ b/AMD Power Gadget/GraphView.swift
@@ -33,12 +33,11 @@ class GraphView: NSView {
     @IBInspectable var viewBottomPercentage: CGFloat = 0;
     
     var dataPoints : [Double] = []
-    var sortedDataPoint : [Double] = []
     var viewTop : CGFloat = 100;
     var viewBottom : CGFloat = 0;
     var viewHeight : CGFloat = 100;
     
-    let gridDivLines: [Double] = [0, 0.15, 0.25, 0.35, 0.5, 0.6, 0.8, 0.9, 1]
+    let gridDivLines: [Double] = [0, 0.2, 0.4, 0.6, 0.8, 1]
     let maxDataPoints = 30
     
     let dummyData: [Double] = [1,3,2]
@@ -113,28 +112,21 @@ class GraphView: NSView {
     
     func addData(value: Double){
         dataPoints.append(value);
-        sortedDataPoint.append(value.rounded())
         
         if dataPoints.count > maxDataPoints {
             dataPoints.remove(at: 0)
         }
-        
-        if sortedDataPoint.count > maxDataPoints {
-            let countedSet = NSCountedSet(array: sortedDataPoint)
-            let mostFrequent = countedSet.max { countedSet.count(for: $0) < countedSet.count(for: $1) }
-            
-            sortedDataPoint.remove(at: sortedDataPoint.firstIndex(of: mostFrequent as! Double)!)
+                
+        if (value < dataMin || dataMin == 0) {
+            dataMin = value.rounded(FloatingPointRoundingRule.down)
         }
-        
-        sortedDataPoint = sortedDataPoint.sorted()
-        
-        dataMax = sortedDataPoint.max()!
-        dataMin = sortedDataPoint.min()!
+        if (value > dataMax) {
+            dataMax = value.rounded(FloatingPointRoundingRule.up)
+        }
         
         //thanks to yurkins for the fix
         dataDiff = max(dataMax - dataMin, 1)
 
-        
         setNeedsDisplay(bounds)
     }
     
@@ -153,7 +145,7 @@ class GraphView: NSView {
         var lastHeight : CGFloat = -1000;
         let minSpacing : CGFloat = 20;
         for v in gridDivLines{
-            let valueOfV = sortedDataPoint[Int(Double(sortedDataPoint.count-1) * v)]
+            let valueOfV = dataMin + dataDiff * v
             let lineHeight = viewHeight * CGFloat((valueOfV - dataMin) / (dataDiff)) + viewBottom
             
             if abs(lineHeight - lastHeight)  < minSpacing {


### PR DESCRIPTION
While working on multiple lines per graph the sortedDataPoints made things unnecessary complicated. It also leads to lines going out of the graph after running for some time in a narrow band.

The new implementation has a few advantages: 
* No more values outside of the graph
* Evenly spaced horizontal lines
* All time min/max are readable as the lowest/upper most lines
* Simpler implementation

before:
![Screenshot 2020-05-15 at 10 20 00](https://user-images.githubusercontent.com/61966108/82027094-00256b80-9694-11ea-838c-1097267ed53b.png)


after:
![Screenshot 2020-05-15 at 09 49 08](https://user-images.githubusercontent.com/61966108/82026984-d5d3ae00-9693-11ea-9b03-56c6f558e06c.png)

