### PR TITLE
Add support for IT8688E SuperIO chip

### DIFF
--- a/AMDRyzenCPUPowerManagement/AMDRyzenCPUPowerManagement.cpp
+++ b/AMDRyzenCPUPowerManagement/AMDRyzenCPUPowerManagement.cpp
@@ -702,6 +702,7 @@ bool AMDRyzenCPUPowerManagement::initSuperIO(uint16_t *chipIntel){
     superIO = nullptr;
     if(!superIO) superIO = ISSuperIONCT668X::getDevice(&savedSMCChipIntel);
     if(!superIO) superIO = ISSuperIONCT67XXFamily::getDevice(&savedSMCChipIntel);
+    if(!superIO) superIO = ISSuperIOIT8688E::getDevice(&savedSMCChipIntel);
     
     *chipIntel = savedSMCChipIntel;
     

--- a/AMDRyzenCPUPowerManagement/AMDRyzenCPUPowerManagement.hpp
+++ b/AMDRyzenCPUPowerManagement/AMDRyzenCPUPowerManagement.hpp
@@ -26,6 +26,7 @@
 
 #include "SuperIO/ISSuperIONCT668X.hpp"
 #include "SuperIO/ISSuperIONCT67XXFamily.hpp"
+#include "SuperIO/ISSuperIOIT8688E.hpp"
 
 #include <i386/cpuid.h>
 

--- a/AMDRyzenCPUPowerManagement/SuperIO/ISSuperIOIT8688E.cpp
+++ b/AMDRyzenCPUPowerManagement/SuperIO/ISSuperIOIT8688E.cpp
@@ -21,14 +21,15 @@ ISSuperIOIT8688E::ISSuperIOIT8688E(int psel, uint16_t addr, uint16_t chipIntel){
     
     //backup default ctrl mode
     for (int i = 0; i < activeFansOnSystem; i++) {
-        fanDefaultControlMode[i] = readByte(kFAN_CTRL_MODE_REGS[i]);
+        fanDefaultControlMode[i] = readByte(kFAN_PWM_CTRL_REGS[i]);
+        fanDefaultExtControlMode[i] = readByte(kFAN_PWM_CTRL_EXT_REGS[i]);
     }
 }
 
 ISSuperIOIT8688E* ISSuperIOIT8688E::getDevice(uint16_t *chipIntel){
     
     i386_ioport_t regport = 0;
-    uint8_t deviceID=0, revision=0;
+    uint8_t deviceID = 0, revision = 0;
     bool found = false;
     int portSel = 0;
     IOLog("probe IT8688E\n");
@@ -46,37 +47,42 @@ ISSuperIOIT8688E* ISSuperIOIT8688E::getDevice(uint16_t *chipIntel){
         outb(regport, 0x01);
         outb(regport, 0x55);
         
-        if (regport == 0x4E) {
+        if (regport == 0x4E)
+        {
           outb(regport, 0xAA);
-        } else {
+        }
+        else
+        {
           outb(regport, 0x55);
         }
         
-        
         deviceID = ISLPCPort::readByte(portSel, ISLPCPort::kCHIP_ID_REG);
         revision = ISLPCPort::readByte(portSel, ISLPCPort::kCHIP_REVISION_REG);
-        found = false;
         
         switch ((deviceID << 8) | revision) {
             case CHIP_IT8688E:
                 found = true;
                 IOLog("IT8688E chip identified\n");
                 break;
-                
             default:
-                
                 break;
         }
         
         
-        if(found) break;
-        else{
+        if (found)
+        {
+            break;
+        }
+        else
+        {
             //close port
-            if (regport != 0x4E) {
+            if (regport != 0x4E)
+            {
               outb(regport, 0x02);
             }
         }
     }
+    
     *chipIntel = (deviceID << 8) | revision;
     if(!found) return nullptr;
     
@@ -90,9 +96,6 @@ ISSuperIOIT8688E* ISSuperIOIT8688E::getDevice(uint16_t *chipIntel){
     if(ISLPCPort::readWord(portSel, ISLPCPort::kBASE_ADDRESS_REGISTER) != devAddr){
         IOLog("IT8688E address verify failed");
     }
-    
-    IOLog("Chip address: 0x%X\n", devAddr);
-    IOLog("Chip version: 0x%X\n", (uint8_t)(ISLPCPort::readByte(portSel, CHIP_VERSION_REGISTER) & 0x0F));
 
     ISLPCPort::select(portSel, CHIP_GPIO_LDN);
     uint16_t gpioAddress = ISLPCPort::readWord(portSel, ISLPCPort::kBASE_ADDRESS_REGISTER + 2);
@@ -111,49 +114,54 @@ ISSuperIOIT8688E* ISSuperIOIT8688E::getDevice(uint16_t *chipIntel){
     return new ISSuperIOIT8688E(portSel, devAddr, *chipIntel); // ToDo Add GPIO Addr
 }
 
-uint8_t ISSuperIOIT8688E::readByte(uint16_t addr){
-    IOLog("ReadByte Addr: 0x%X\n", addr);
+uint8_t ISSuperIOIT8688E::readByte(uint16_t addr)
+{
     outb(chipAddr + CHIP_ADDR_REG_OFFSET, addr & 0xFF);
     return inb(chipAddr + CHIP_DAT_REG_OFFSET);
 }
 
-uint16_t ISSuperIOIT8688E::readWord(uint16_t addr){
-    IOLog("ReadWord Addr: 0x%X\n", addr);
+uint16_t ISSuperIOIT8688E::readWord(uint16_t addr)
+{
     return (readByte(addr) << 8) | readByte(addr + 1);
 }
 
-void ISSuperIOIT8688E::writeByte(uint16_t addr, uint8_t val){
-    IOLog("WriteByte Addr: 0x%X, 0x%X\n", addr, val);
+void ISSuperIOIT8688E::writeByte(uint16_t addr, uint8_t val)
+{
     outb(chipAddr + CHIP_ADDR_REG_OFFSET, addr & 0xFF);
     outb(chipAddr + CHIP_DAT_REG_OFFSET, val);
 }
 
-int ISSuperIOIT8688E::getNumberOfFans(){
+int ISSuperIOIT8688E::getNumberOfFans()
+{
     return activeFansOnSystem;
 }
 
-const char *ISSuperIOIT8688E::getReadableStringForFan(int fan){
+const char *ISSuperIOIT8688E::getReadableStringForFan(int fan)
+{
     if(fan > activeFansOnSystem) return nullptr;
     return kFAN_READABLE_STRS[fan];
 }
 
-uint32_t ISSuperIOIT8688E::getRPMForFan(int fan){
+uint32_t ISSuperIOIT8688E::getRPMForFan(int fan)
+{
     if(fan > activeFansOnSystem) return 0;
     return fanRPMs[fan];
 }
 
-bool ISSuperIOIT8688E::getFanAutoControlMode(int fan){
+bool ISSuperIOIT8688E::getFanAutoControlMode(int fan)
+{
     if(fan > activeFansOnSystem) return 0;
     return fanControlMode[fan] != 0;
 }
 
-uint8_t ISSuperIOIT8688E::getFanThrottle(int fan){
+uint8_t ISSuperIOIT8688E::getFanThrottle(int fan)
+{
     if(fan > activeFansOnSystem) return 0;
-    return fanThrottles[fan];
+    return fanControlMode[fan];
 }
 
-void ISSuperIOIT8688E::updateFanRPMS(){
-   
+void ISSuperIOIT8688E::updateFanRPMS()
+{
     for (int i = 0; i < activeFansOnSystem; i++)
     {
         int value = readByte(kFAN_RPM_REGS[i]);
@@ -165,41 +173,32 @@ void ISSuperIOIT8688E::updateFanRPMS(){
         }
         else
         {
-          IOLog("Fan RPM else condition");
           fanRPMs[i] = 0;
         }
-        IOLog("fan %d: %d\n", i, (int)fanRPMs[i]);
     }
 }
 
-void ISSuperIOIT8688E::updateFanControl(){
+void ISSuperIOIT8688E::updateFanControl()
+{
     for (int i = 0; i < activeFansOnSystem; i++)
     {
-        uint16_t value = readByte(kFAN_PWM_CTRL_REGS[i]);
-
-        if ((value & 0x80) > 0)
-        {
-           fanControlMode[i] = 255;
-        }
-        else
-        {
-            value = readByte(kFAN_PWM_CTRL_EXT_REGS[i]);
-            fanControlMode[i] = value * 100.0f / 0xFF;
-        }
-        
-        IOLog("fan pwm %d:\n", fanControlMode[i]);
+        fanControlMode[i] = readByte(kFAN_PWM_CTRL_EXT_REGS[i]);
     }
 }
 
-void ISSuperIOIT8688E::overrideFanControl(int fan, uint8_t thr){
+void ISSuperIOIT8688E::overrideFanControl(int fan, uint8_t thr)
+{
     if(fan >= activeFansOnSystem) return;
-
     writeByte(kFAN_MAIN_CTRL_REG, (readByte(kFAN_MAIN_CTRL_REG) | (1 << fan)));
     writeByte(kFAN_PWM_CTRL_REGS[fan], (fanDefaultControlMode[fan] & 0x7F));
     writeByte(kFAN_PWM_CTRL_EXT_REGS[fan], thr);
 }
 
-void ISSuperIOIT8688E::setDefaultFanControl(int fan){
+void ISSuperIOIT8688E::setDefaultFanControl(int fan)
+{
     if(fan >= activeFansOnSystem) return;
-    writeByte(kFAN_CTRL_MODE_REGS[fan], fanDefaultControlMode[fan]);
+    writeByte(kFAN_MAIN_CTRL_REG, (readByte(kFAN_MAIN_CTRL_REG) ^ (1 << fan)));
+    writeByte(kFAN_MAIN_CTRL_REG, (readByte(kFAN_MAIN_CTRL_REG) ^ (1 << fan))); // Fan 0 only goes back to auto mode when MAIN_CTRL_REG is swichted twice
+    writeByte(kFAN_PWM_CTRL_REGS[fan], fanDefaultControlMode[fan]);
+    writeByte(kFAN_PWM_CTRL_EXT_REGS[fan], fanDefaultExtControlMode[fan]);
 }

--- a/AMDRyzenCPUPowerManagement/SuperIO/ISSuperIOIT8688E.cpp
+++ b/AMDRyzenCPUPowerManagement/SuperIO/ISSuperIOIT8688E.cpp
@@ -1,0 +1,205 @@
+//
+//  ISSuperIOIT8688E.cpp
+//  AMDRyzenCPUPowerManagement
+//
+//  Created by Maurice on 25.05.20.
+//  Copyright © 2020 trulyspinach. All rights reserved.
+//
+
+#include "ISSuperIOIT8688E.hpp"
+
+ISSuperIOIT8688E::ISSuperIOIT8688E(int psel, uint16_t addr, uint16_t chipIntel){
+    lpcPortSel = psel;
+    chipAddr = addr;
+    
+    switch (chipIntel) {
+        case CHIP_IT8688E:
+        default:
+            activeFansOnSystem = 5;
+            break;
+    }
+    
+    //backup default ctrl mode
+    for (int i = 0; i < activeFansOnSystem; i++) {
+        fanDefaultControlMode[i] = readByte(kFAN_CTRL_MODE_REGS[i]);
+    }
+}
+
+ISSuperIOIT8688E* ISSuperIOIT8688E::getDevice(uint16_t *chipIntel){
+    
+    i386_ioport_t regport = 0;
+    uint8_t deviceID=0, revision=0;
+    bool found = false;
+    int portSel = 0;
+    IOLog("probe IT8688E\n");
+    
+    for (; portSel < 2; portSel++) {
+        regport = ISLPCPort::kREGISTER_PORTS[portSel];
+        
+        if (regport != 0x2E && regport != 0x4E)
+        {
+            break;
+        }
+        
+        //open port
+        outb(regport, 0x87);
+        outb(regport, 0x01);
+        outb(regport, 0x55);
+        
+        if (regport == 0x4E) {
+          outb(regport, 0xAA);
+        } else {
+          outb(regport, 0x55);
+        }
+        
+        
+        deviceID = ISLPCPort::readByte(portSel, ISLPCPort::kCHIP_ID_REG);
+        revision = ISLPCPort::readByte(portSel, ISLPCPort::kCHIP_REVISION_REG);
+        found = false;
+        
+        switch ((deviceID << 8) | revision) {
+            case CHIP_IT8688E:
+                found = true;
+                IOLog("IT8688E chip identified\n");
+                break;
+                
+            default:
+                
+                break;
+        }
+        
+        
+        if(found) break;
+        else{
+            //close port
+            if (regport != 0x4E) {
+              outb(regport, 0x02);
+            }
+        }
+    }
+    *chipIntel = (deviceID << 8) | revision;
+    if(!found) return nullptr;
+    
+    IOLog("SMC Chip id:%X revision:%X \n", deviceID, revision);
+    ISLPCPort::select(portSel, CHIP_ENVIRONMENT_CONTROLLER_LDN);
+    
+    uint16_t devAddr = ISLPCPort::readWord(portSel, ISLPCPort::kBASE_ADDRESS_REGISTER);
+    
+    //verify addr
+    IOSleep(100);
+    if(ISLPCPort::readWord(portSel, ISLPCPort::kBASE_ADDRESS_REGISTER) != devAddr){
+        IOLog("IT8688E address verify failed");
+    }
+    
+    IOLog("Chip address: 0x%X\n", devAddr);
+    IOLog("Chip version: 0x%X\n", (uint8_t)(ISLPCPort::readByte(portSel, CHIP_VERSION_REGISTER) & 0x0F));
+
+    ISLPCPort::select(portSel, CHIP_GPIO_LDN);
+    uint16_t gpioAddress = ISLPCPort::readWord(portSel, ISLPCPort::kBASE_ADDRESS_REGISTER + 2);
+    
+    //verify gpio addr
+    IOSleep(100);
+    if(ISLPCPort::readWord(portSel, ISLPCPort::kBASE_ADDRESS_REGISTER + 2) != gpioAddress){
+        IOLog("IT8688E gpio address verify failed");
+    }
+    
+    //close port
+    if (regport != 0x4E) {
+      outb(regport, 0x02);
+    }
+    
+    return new ISSuperIOIT8688E(portSel, devAddr, *chipIntel); // ToDo Add GPIO Addr
+}
+
+uint8_t ISSuperIOIT8688E::readByte(uint16_t addr){
+    IOLog("ReadByte Addr: 0x%X\n", addr);
+    outb(chipAddr + CHIP_ADDR_REG_OFFSET, addr & 0xFF);
+    return inb(chipAddr + CHIP_DAT_REG_OFFSET);
+}
+
+uint16_t ISSuperIOIT8688E::readWord(uint16_t addr){
+    IOLog("ReadWord Addr: 0x%X\n", addr);
+    return (readByte(addr) << 8) | readByte(addr + 1);
+}
+
+void ISSuperIOIT8688E::writeByte(uint16_t addr, uint8_t val){
+    IOLog("WriteByte Addr: 0x%X, 0x%X\n", addr, val);
+    outb(chipAddr + CHIP_ADDR_REG_OFFSET, addr & 0xFF);
+    outb(chipAddr + CHIP_DAT_REG_OFFSET, val);
+}
+
+int ISSuperIOIT8688E::getNumberOfFans(){
+    return activeFansOnSystem;
+}
+
+const char *ISSuperIOIT8688E::getReadableStringForFan(int fan){
+    if(fan > activeFansOnSystem) return nullptr;
+    return kFAN_READABLE_STRS[fan];
+}
+
+uint32_t ISSuperIOIT8688E::getRPMForFan(int fan){
+    if(fan > activeFansOnSystem) return 0;
+    return fanRPMs[fan];
+}
+
+bool ISSuperIOIT8688E::getFanAutoControlMode(int fan){
+    if(fan > activeFansOnSystem) return 0;
+    return fanControlMode[fan] != 0;
+}
+
+uint8_t ISSuperIOIT8688E::getFanThrottle(int fan){
+    if(fan > activeFansOnSystem) return 0;
+    return fanThrottles[fan];
+}
+
+void ISSuperIOIT8688E::updateFanRPMS(){
+   
+    for (int i = 0; i < activeFansOnSystem; i++)
+    {
+        int value = readByte(kFAN_RPM_REGS[i]);
+        value |= readByte(kFAN_RPM_EXT_REGS[i]) << 8;
+
+        if (value > 0x3f)
+        {
+          fanRPMs[i] = (value < 0xffff) ? 1.35e6f / (value * 2) : 0;
+        }
+        else
+        {
+          IOLog("Fan RPM else condition");
+          fanRPMs[i] = 0;
+        }
+        IOLog("fan %d: %d\n", i, (int)fanRPMs[i]);
+    }
+}
+
+void ISSuperIOIT8688E::updateFanControl(){
+    for (int i = 0; i < activeFansOnSystem; i++)
+    {
+        uint16_t value = readByte(kFAN_PWM_CTRL_REGS[i]);
+
+        if ((value & 0x80) > 0)
+        {
+           fanControlMode[i] = 255;
+        }
+        else
+        {
+            value = readByte(kFAN_PWM_CTRL_EXT_REGS[i]);
+            fanControlMode[i] = value * 100.0f / 0xFF;
+        }
+        
+        IOLog("fan pwm %d:\n", fanControlMode[i]);
+    }
+}
+
+void ISSuperIOIT8688E::overrideFanControl(int fan, uint8_t thr){
+    if(fan >= activeFansOnSystem) return;
+
+    writeByte(kFAN_MAIN_CTRL_REG, (readByte(kFAN_MAIN_CTRL_REG) | (1 << fan)));
+    writeByte(kFAN_PWM_CTRL_REGS[fan], (fanDefaultControlMode[fan] & 0x7F));
+    writeByte(kFAN_PWM_CTRL_EXT_REGS[fan], thr);
+}
+
+void ISSuperIOIT8688E::setDefaultFanControl(int fan){
+    if(fan >= activeFansOnSystem) return;
+    writeByte(kFAN_CTRL_MODE_REGS[fan], fanDefaultControlMode[fan]);
+}

--- a/AMDRyzenCPUPowerManagement/SuperIO/ISSuperIOIT8688E.cpp
+++ b/AMDRyzenCPUPowerManagement/SuperIO/ISSuperIOIT8688E.cpp
@@ -120,7 +120,7 @@ ISSuperIOIT8688E* ISSuperIOIT8688E::getDevice(uint16_t* chipIntel)
         outb(regport, 0x02);
     }
 
-    return new ISSuperIOIT8688E(portSel, devAddr, *chipIntel);  // ToDo Add GPIO Addr
+    return new ISSuperIOIT8688E(portSel, devAddr, *chipIntel);  //TODO: Add GPIO Addr
 }
 
 uint8_t ISSuperIOIT8688E::readByte(uint16_t addr)
@@ -215,7 +215,7 @@ void ISSuperIOIT8688E::setDefaultFanControl(int fan)
     writeByte(kFAN_MAIN_CTRL_REG, (readByte(kFAN_MAIN_CTRL_REG) ^ (1 << fan)));
     writeByte(kFAN_MAIN_CTRL_REG,
               (readByte(kFAN_MAIN_CTRL_REG) ^
-               (1 << fan)));  // Fan 0 only goes back to auto mode when MAIN_CTRL_REG is swichted twice
+               (1 << fan)));  // Fan 0 only goes back to auto mode when MAIN_CTRL_REG is switched twice
     writeByte(kFAN_PWM_CTRL_REGS[fan], fanDefaultControlMode[fan]);
     writeByte(kFAN_PWM_CTRL_EXT_REGS[fan], fanDefaultExtControlMode[fan]);
 }

--- a/AMDRyzenCPUPowerManagement/SuperIO/ISSuperIOIT8688E.hpp
+++ b/AMDRyzenCPUPowerManagement/SuperIO/ISSuperIOIT8688E.hpp
@@ -20,13 +20,9 @@
 
 #define IT8688E_MAX_NUMFAN 5
 
-#define CHIP_SIO_OPEN 0x87
-#define CHIP_SIO_CLOSE 0x02
 #define CHIP_ENVIRONMENT_CONTROLLER_LDN 0x04
-#define CHIP_VERSION_REGISTER 0x22
 #define CHIP_GPIO_LDN 0x07
 
-#define CHIP_TACHOMETER_DIVISOR_REGISTER 0x0B
 #define CHIP_ADDR_REG_OFFSET 0x05
 #define CHIP_DAT_REG_OFFSET 0x06
 
@@ -49,7 +45,6 @@ public:
     ISSuperIOIT8688E(int psel, uint16_t addr, uint16_t chipIntel);
     
     int fanRPMs[IT8688E_MAX_NUMFAN];
-    uint8_t fanThrottles[IT8688E_MAX_NUMFAN];
     uint8_t fanControlMode[IT8688E_MAX_NUMFAN];
     
     int activeFansOnSystem = 0;
@@ -74,12 +69,12 @@ private:
     static constexpr uint16_t kFAN_RPM_EXT_REGS[] = { 0x18, 0x19, 0x1a, 0x81, 0x83 };
     static constexpr uint16_t kFAN_PWM_CTRL_REGS[] = { 0x15, 0x16, 0x17, 0x7f, 0xa7 };
     static constexpr uint16_t kFAN_PWM_CTRL_EXT_REGS[] = { 0x63, 0x6b, 0x73, 0x7b, 0xa3 };
-    static constexpr uint16_t kFAN_CTRL_MODE_REGS[] = { 0x15, 0x16, 0x17, 0x7f, 0xa7 };
     
     int lpcPortSel = 0;
     
     uint16_t chipAddr = 0;
     uint8_t fanDefaultControlMode[IT8688E_MAX_NUMFAN];
+    uint8_t fanDefaultExtControlMode[IT8688E_MAX_NUMFAN];
     
     uint8_t readByte(uint16_t addr);
     uint16_t readWord(uint16_t addr);

--- a/AMDRyzenCPUPowerManagement/SuperIO/ISSuperIOIT8688E.hpp
+++ b/AMDRyzenCPUPowerManagement/SuperIO/ISSuperIOIT8688E.hpp
@@ -26,59 +26,56 @@
 #define CHIP_ADDR_REG_OFFSET 0x05
 #define CHIP_DAT_REG_OFFSET 0x06
 
+class ISSuperIOIT8688E : public ISSuperIOSMCFamily
+{
 
-class ISSuperIOIT8688E : public ISSuperIOSMCFamily {
-
-    
-public:
-    static constexpr const char *kFAN_READABLE_STRS[] = {
+  public:
+    static constexpr const char* kFAN_READABLE_STRS[] = {
         "CPU Fan",
         "System 1 Fan",
         "System 2 Fan",
         "PCH Fan",
         "CPU OPT Fan",
     };
-    
-    static ISSuperIOIT8688E* getDevice(uint16_t *chipIntel);
-    
-    
+
+    static ISSuperIOIT8688E* getDevice(uint16_t* chipIntel);
+
     ISSuperIOIT8688E(int psel, uint16_t addr, uint16_t chipIntel);
-    
+
     int fanRPMs[IT8688E_MAX_NUMFAN];
     uint8_t fanControlMode[IT8688E_MAX_NUMFAN];
-    
+
     int activeFansOnSystem = 0;
-    
+
     int getNumberOfFans() override;
-    const char *getReadableStringForFan(int fan) override;
-    
+    const char* getReadableStringForFan(int fan) override;
+
     uint32_t getRPMForFan(int fan) override;
     bool getFanAutoControlMode(int fan) override;
     uint8_t getFanThrottle(int fan) override;
-    
+
     void updateFanRPMS() override;
     void updateFanControl() override;
-    
+
     void overrideFanControl(int fan, uint8_t thr) override;
     void setDefaultFanControl(int fan) override;
-    
-private:
-    
+
+  private:
     static constexpr uint16_t kFAN_MAIN_CTRL_REG = 0x13;
-    static constexpr uint16_t kFAN_RPM_REGS[] = { 0x0d, 0x0e, 0x0f, 0x80, 0x82 };
-    static constexpr uint16_t kFAN_RPM_EXT_REGS[] = { 0x18, 0x19, 0x1a, 0x81, 0x83 };
-    static constexpr uint16_t kFAN_PWM_CTRL_REGS[] = { 0x15, 0x16, 0x17, 0x7f, 0xa7 };
-    static constexpr uint16_t kFAN_PWM_CTRL_EXT_REGS[] = { 0x63, 0x6b, 0x73, 0x7b, 0xa3 };
-    
+    static constexpr uint16_t kFAN_RPM_REGS[] = {0x0d, 0x0e, 0x0f, 0x80, 0x82};
+    static constexpr uint16_t kFAN_RPM_EXT_REGS[] = {0x18, 0x19, 0x1a, 0x81, 0x83};
+    static constexpr uint16_t kFAN_PWM_CTRL_REGS[] = {0x15, 0x16, 0x17, 0x7f, 0xa7};
+    static constexpr uint16_t kFAN_PWM_CTRL_EXT_REGS[] = {0x63, 0x6b, 0x73, 0x7b, 0xa3};
+
     int lpcPortSel = 0;
-    
+
     uint16_t chipAddr = 0;
     uint8_t fanDefaultControlMode[IT8688E_MAX_NUMFAN];
     uint8_t fanDefaultExtControlMode[IT8688E_MAX_NUMFAN];
-    
+
     uint8_t readByte(uint16_t addr);
     uint16_t readWord(uint16_t addr);
-    
+
     void writeByte(uint16_t addr, uint8_t val);
 };
 

--- a/AMDRyzenCPUPowerManagement/SuperIO/ISSuperIOIT8688E.hpp
+++ b/AMDRyzenCPUPowerManagement/SuperIO/ISSuperIOIT8688E.hpp
@@ -1,0 +1,90 @@
+//
+//  ISSuperIOIT8688E.hpp
+//  AMDRyzenCPUPowerManagement
+//
+//  Created by Maurice on 25.05.20.
+//  Copyright © 2020 trulyspinach. All rights reserved.
+//
+
+#ifndef ISSuperIOIT8688E_hpp
+#define ISSuperIOIT8688E_hpp
+
+#include <IOKit/IOLib.h>
+
+#include <architecture/i386/pio.h>
+
+#include "ISLPCPort.h"
+#include "ISSuperIOSMCFamily.hpp"
+
+#define CHIP_IT8688E 0x8688
+
+#define IT8688E_MAX_NUMFAN 5
+
+#define CHIP_SIO_OPEN 0x87
+#define CHIP_SIO_CLOSE 0x02
+#define CHIP_ENVIRONMENT_CONTROLLER_LDN 0x04
+#define CHIP_VERSION_REGISTER 0x22
+#define CHIP_GPIO_LDN 0x07
+
+#define CHIP_TACHOMETER_DIVISOR_REGISTER 0x0B
+#define CHIP_ADDR_REG_OFFSET 0x05
+#define CHIP_DAT_REG_OFFSET 0x06
+
+
+class ISSuperIOIT8688E : public ISSuperIOSMCFamily {
+
+    
+public:
+    static constexpr const char *kFAN_READABLE_STRS[] = {
+        "CPU Fan",
+        "System 1 Fan",
+        "System 2 Fan",
+        "PCH Fan",
+        "CPU OPT Fan",
+    };
+    
+    static ISSuperIOIT8688E* getDevice(uint16_t *chipIntel);
+    
+    
+    ISSuperIOIT8688E(int psel, uint16_t addr, uint16_t chipIntel);
+    
+    int fanRPMs[IT8688E_MAX_NUMFAN];
+    uint8_t fanThrottles[IT8688E_MAX_NUMFAN];
+    uint8_t fanControlMode[IT8688E_MAX_NUMFAN];
+    
+    int activeFansOnSystem = 0;
+    
+    int getNumberOfFans() override;
+    const char *getReadableStringForFan(int fan) override;
+    
+    uint32_t getRPMForFan(int fan) override;
+    bool getFanAutoControlMode(int fan) override;
+    uint8_t getFanThrottle(int fan) override;
+    
+    void updateFanRPMS() override;
+    void updateFanControl() override;
+    
+    void overrideFanControl(int fan, uint8_t thr) override;
+    void setDefaultFanControl(int fan) override;
+    
+private:
+    
+    static constexpr uint16_t kFAN_MAIN_CTRL_REG = 0x13;
+    static constexpr uint16_t kFAN_RPM_REGS[] = { 0x0d, 0x0e, 0x0f, 0x80, 0x82 };
+    static constexpr uint16_t kFAN_RPM_EXT_REGS[] = { 0x18, 0x19, 0x1a, 0x81, 0x83 };
+    static constexpr uint16_t kFAN_PWM_CTRL_REGS[] = { 0x15, 0x16, 0x17, 0x7f, 0xa7 };
+    static constexpr uint16_t kFAN_PWM_CTRL_EXT_REGS[] = { 0x63, 0x6b, 0x73, 0x7b, 0xa3 };
+    static constexpr uint16_t kFAN_CTRL_MODE_REGS[] = { 0x15, 0x16, 0x17, 0x7f, 0xa7 };
+    
+    int lpcPortSel = 0;
+    
+    uint16_t chipAddr = 0;
+    uint8_t fanDefaultControlMode[IT8688E_MAX_NUMFAN];
+    
+    uint8_t readByte(uint16_t addr);
+    uint16_t readWord(uint16_t addr);
+    
+    void writeByte(uint16_t addr, uint8_t val);
+};
+
+#endif /* ISSuperIOIT8688E_hpp */

--- a/SMCAMDProcessor.xcodeproj/project.pbxproj
+++ b/SMCAMDProcessor.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5B72086C247C884C00BF7492 /* ISSuperIOIT8688E.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5B72086A247C884C00BF7492 /* ISSuperIOIT8688E.hpp */; };
+		5B72086D247C884C00BF7492 /* ISSuperIOIT8688E.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5B72086B247C884C00BF7492 /* ISSuperIOIT8688E.cpp */; };
 		B5011EA1242E01CC009FB2A2 /* SMCAMDProcessor.hpp in Headers */ = {isa = PBXBuildFile; fileRef = B5011EA0242E01CC009FB2A2 /* SMCAMDProcessor.hpp */; };
 		B5011EA3242E01CC009FB2A2 /* SMCAMDProcessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5011EA2242E01CC009FB2A2 /* SMCAMDProcessor.cpp */; };
 		B56162C72400EF770006A7D8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56162C62400EF770006A7D8 /* AppDelegate.swift */; };
@@ -45,6 +47,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		5B72086A247C884C00BF7492 /* ISSuperIOIT8688E.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ISSuperIOIT8688E.hpp; sourceTree = "<group>"; };
+		5B72086B247C884C00BF7492 /* ISSuperIOIT8688E.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ISSuperIOIT8688E.cpp; sourceTree = "<group>"; };
 		B5011E9E242E01CC009FB2A2 /* SMCAMDProcessor.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SMCAMDProcessor.kext; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5011EA0242E01CC009FB2A2 /* SMCAMDProcessor.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = SMCAMDProcessor.hpp; sourceTree = "<group>"; };
 		B5011EA2242E01CC009FB2A2 /* SMCAMDProcessor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SMCAMDProcessor.cpp; sourceTree = "<group>"; };
@@ -250,6 +254,8 @@
 		B5810041246D627700A38AB7 /* SuperIO */ = {
 			isa = PBXGroup;
 			children = (
+				5B72086B247C884C00BF7492 /* ISSuperIOIT8688E.cpp */,
+				5B72086A247C884C00BF7492 /* ISSuperIOIT8688E.hpp */,
 				B5810042246D629C00A38AB7 /* ISSuperIONCT67XXFamily.cpp */,
 				B5810043246D629C00A38AB7 /* ISSuperIONCT67XXFamily.hpp */,
 				B5DF4AB3247156F200663498 /* ISSuperIONCT668X.cpp */,
@@ -301,6 +307,7 @@
 				B5810045246D629C00A38AB7 /* ISSuperIONCT67XXFamily.hpp in Headers */,
 				B57C7E972424EFFF00C86B68 /* cpu_topology.h in Headers */,
 				B564A5CA240B8256000FF929 /* LegacyIOUserClient.h in Headers */,
+				5B72086C247C884C00BF7492 /* ISSuperIOIT8688E.hpp in Headers */,
 				B5DDAAC224714A1500A7572D /* ISSuperIOSMCFamily.hpp in Headers */,
 				B57D280923F66C8E002BC699 /* AMDRyzenCPUPowerManagement.hpp in Headers */,
 			);
@@ -466,6 +473,7 @@
 			files = (
 				B5DF4AB5247156F200663498 /* ISSuperIONCT668X.cpp in Sources */,
 				B584F5CC242E2CBE007DEA77 /* pmAMDRyzen.c in Sources */,
+				5B72086D247C884C00BF7492 /* ISSuperIOIT8688E.cpp in Sources */,
 				B5D20189241B85E800BBD06A /* kernel_resolver.c in Sources */,
 				B57D280B23F66C8E002BC699 /* AMDRyzenCPUPMUserClient.cpp in Sources */,
 				B57D280723F66C8E002BC699 /* AMDRyzenCPUPowerManagement.cpp in Sources */,

--- a/SMCAMDProcessor.xcodeproj/xcuserdata/qihaoyan.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/SMCAMDProcessor.xcodeproj/xcuserdata/qihaoyan.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>AMD Power Gadget.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>2</integer>
 		</dict>
 		<key>AMDRyzenCPUPowerManagement.xcscheme_^#shared#^_</key>
 		<dict>
@@ -17,7 +17,7 @@
 		<key>SMCAMDProcessor.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>


### PR DESCRIPTION
This PR enables the monitoring and modification of the fan speeds for IT8688E equipped mainboards.

Tested on: Gigabyte X570 Aorus Pro