### PR TITLE
Add support for IT8665E and more generic name scheme

### DIFF
--- a/AMDRyzenCPUPowerManagement/AMDRyzenCPUPowerManagement.cpp
+++ b/AMDRyzenCPUPowerManagement/AMDRyzenCPUPowerManagement.cpp
@@ -702,7 +702,7 @@ bool AMDRyzenCPUPowerManagement::initSuperIO(uint16_t *chipIntel){
     superIO = nullptr;
     if(!superIO) superIO = ISSuperIONCT668X::getDevice(&savedSMCChipIntel);
     if(!superIO) superIO = ISSuperIONCT67XXFamily::getDevice(&savedSMCChipIntel);
-    if(!superIO) superIO = ISSuperIOIT8688E::getDevice(&savedSMCChipIntel);
+    if(!superIO) superIO = ISSuperIOIT86XXE::getDevice(&savedSMCChipIntel);
     
     *chipIntel = savedSMCChipIntel;
     

--- a/AMDRyzenCPUPowerManagement/AMDRyzenCPUPowerManagement.hpp
+++ b/AMDRyzenCPUPowerManagement/AMDRyzenCPUPowerManagement.hpp
@@ -26,7 +26,7 @@
 
 #include "SuperIO/ISSuperIONCT668X.hpp"
 #include "SuperIO/ISSuperIONCT67XXFamily.hpp"
-#include "SuperIO/ISSuperIOIT8688E.hpp"
+#include "SuperIO/ISSuperIOIT86XXE.hpp"
 
 #include <i386/cpuid.h>
 

--- a/AMDRyzenCPUPowerManagement/SuperIO/ISSuperIOIT86XXE.hpp
+++ b/AMDRyzenCPUPowerManagement/SuperIO/ISSuperIOIT86XXE.hpp
@@ -1,13 +1,13 @@
 //
-//  ISSuperIOIT8688E.hpp
+//  ISSuperIOIT86XXE.hpp
 //  AMDRyzenCPUPowerManagement
 //
 //  Created by Maurice on 25.05.20.
 //  Copyright © 2020 trulyspinach. All rights reserved.
 //
 
-#ifndef ISSuperIOIT8688E_hpp
-#define ISSuperIOIT8688E_hpp
+#ifndef ISSuperIOIT86XXE_hpp
+#define ISSuperIOIT86XXE_hpp
 
 #include <IOKit/IOLib.h>
 
@@ -18,8 +18,9 @@
 
 #define CHIP_IT8688E 0x8688
 #define CHIP_IT8686E 0x8686
+#define CHIP_IT8665E 0x8665
 
-#define IT8688E_MAX_NUMFAN 5
+#define IT86XXE_MAX_NUMFAN 5
 
 #define CHIP_ENVIRONMENT_CONTROLLER_LDN 0x04
 #define CHIP_GPIO_LDN 0x07
@@ -27,7 +28,7 @@
 #define CHIP_ADDR_REG_OFFSET 0x05
 #define CHIP_DAT_REG_OFFSET 0x06
 
-class ISSuperIOIT8688E : public ISSuperIOSMCFamily
+class ISSuperIOIT86XXE : public ISSuperIOSMCFamily
 {
 
   public:
@@ -39,12 +40,12 @@ class ISSuperIOIT8688E : public ISSuperIOSMCFamily
         "CPU OPT Fan",
     };
 
-    static ISSuperIOIT8688E* getDevice(uint16_t* chipIntel);
+    static ISSuperIOIT86XXE* getDevice(uint16_t* chipIntel);
 
-    ISSuperIOIT8688E(int psel, uint16_t addr, uint16_t chipIntel);
+    ISSuperIOIT86XXE(int psel, uint16_t addr, uint16_t chipIntel);
 
-    int fanRPMs[IT8688E_MAX_NUMFAN];
-    uint8_t fanControlMode[IT8688E_MAX_NUMFAN];
+    int fanRPMs[IT86XXE_MAX_NUMFAN];
+    uint8_t fanControlMode[IT86XXE_MAX_NUMFAN];
 
     int activeFansOnSystem = 0;
 
@@ -71,8 +72,8 @@ class ISSuperIOIT8688E : public ISSuperIOSMCFamily
     int lpcPortSel = 0;
 
     uint16_t chipAddr = 0;
-    uint8_t fanDefaultControlMode[IT8688E_MAX_NUMFAN];
-    uint8_t fanDefaultExtControlMode[IT8688E_MAX_NUMFAN];
+    uint8_t fanDefaultControlMode[IT86XXE_MAX_NUMFAN];
+    uint8_t fanDefaultExtControlMode[IT86XXE_MAX_NUMFAN];
 
     uint8_t readByte(uint16_t addr);
     uint16_t readWord(uint16_t addr);
@@ -80,4 +81,4 @@ class ISSuperIOIT8688E : public ISSuperIOSMCFamily
     void writeByte(uint16_t addr, uint8_t val);
 };
 
-#endif /* ISSuperIOIT8688E_hpp */
+#endif /* ISSuperIOIT86XXE_hpp */

--- a/SMCAMDProcessor.xcodeproj/project.pbxproj
+++ b/SMCAMDProcessor.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		5B72086C247C884C00BF7492 /* ISSuperIOIT8688E.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5B72086A247C884C00BF7492 /* ISSuperIOIT8688E.hpp */; };
-		5B72086D247C884C00BF7492 /* ISSuperIOIT8688E.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5B72086B247C884C00BF7492 /* ISSuperIOIT8688E.cpp */; };
+		5B72086C247C884C00BF7492 /* ISSuperIOIT86XXE.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5B72086A247C884C00BF7492 /* ISSuperIOIT86XXE.hpp */; };
+		5B72086D247C884C00BF7492 /* ISSuperIOIT86XXE.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5B72086B247C884C00BF7492 /* ISSuperIOIT86XXE.cpp */; };
 		B5011EA1242E01CC009FB2A2 /* SMCAMDProcessor.hpp in Headers */ = {isa = PBXBuildFile; fileRef = B5011EA0242E01CC009FB2A2 /* SMCAMDProcessor.hpp */; };
 		B5011EA3242E01CC009FB2A2 /* SMCAMDProcessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B5011EA2242E01CC009FB2A2 /* SMCAMDProcessor.cpp */; };
 		B56162C72400EF770006A7D8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56162C62400EF770006A7D8 /* AppDelegate.swift */; };
@@ -47,8 +47,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		5B72086A247C884C00BF7492 /* ISSuperIOIT8688E.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ISSuperIOIT8688E.hpp; sourceTree = "<group>"; };
-		5B72086B247C884C00BF7492 /* ISSuperIOIT8688E.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ISSuperIOIT8688E.cpp; sourceTree = "<group>"; };
+		5B72086A247C884C00BF7492 /* ISSuperIOIT86XXE.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ISSuperIOIT86XXE.hpp; sourceTree = "<group>"; };
+		5B72086B247C884C00BF7492 /* ISSuperIOIT86XXE.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ISSuperIOIT86XXE.cpp; sourceTree = "<group>"; };
 		B5011E9E242E01CC009FB2A2 /* SMCAMDProcessor.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SMCAMDProcessor.kext; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5011EA0242E01CC009FB2A2 /* SMCAMDProcessor.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = SMCAMDProcessor.hpp; sourceTree = "<group>"; };
 		B5011EA2242E01CC009FB2A2 /* SMCAMDProcessor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SMCAMDProcessor.cpp; sourceTree = "<group>"; };
@@ -254,8 +254,8 @@
 		B5810041246D627700A38AB7 /* SuperIO */ = {
 			isa = PBXGroup;
 			children = (
-				5B72086B247C884C00BF7492 /* ISSuperIOIT8688E.cpp */,
-				5B72086A247C884C00BF7492 /* ISSuperIOIT8688E.hpp */,
+				5B72086B247C884C00BF7492 /* ISSuperIOIT86XXE.cpp */,
+				5B72086A247C884C00BF7492 /* ISSuperIOIT86XXE.hpp */,
 				B5810042246D629C00A38AB7 /* ISSuperIONCT67XXFamily.cpp */,
 				B5810043246D629C00A38AB7 /* ISSuperIONCT67XXFamily.hpp */,
 				B5DF4AB3247156F200663498 /* ISSuperIONCT668X.cpp */,
@@ -307,7 +307,7 @@
 				B5810045246D629C00A38AB7 /* ISSuperIONCT67XXFamily.hpp in Headers */,
 				B57C7E972424EFFF00C86B68 /* cpu_topology.h in Headers */,
 				B564A5CA240B8256000FF929 /* LegacyIOUserClient.h in Headers */,
-				5B72086C247C884C00BF7492 /* ISSuperIOIT8688E.hpp in Headers */,
+				5B72086C247C884C00BF7492 /* ISSuperIOIT86XXE.hpp in Headers */,
 				B5DDAAC224714A1500A7572D /* ISSuperIOSMCFamily.hpp in Headers */,
 				B57D280923F66C8E002BC699 /* AMDRyzenCPUPowerManagement.hpp in Headers */,
 			);
@@ -473,7 +473,7 @@
 			files = (
 				B5DF4AB5247156F200663498 /* ISSuperIONCT668X.cpp in Sources */,
 				B584F5CC242E2CBE007DEA77 /* pmAMDRyzen.c in Sources */,
-				5B72086D247C884C00BF7492 /* ISSuperIOIT8688E.cpp in Sources */,
+				5B72086D247C884C00BF7492 /* ISSuperIOIT86XXE.cpp in Sources */,
 				B5D20189241B85E800BBD06A /* kernel_resolver.c in Sources */,
 				B57D280B23F66C8E002BC699 /* AMDRyzenCPUPMUserClient.cpp in Sources */,
 				B57D280723F66C8E002BC699 /* AMDRyzenCPUPowerManagement.cpp in Sources */,


### PR DESCRIPTION
This enables fan speed monitoring and modification for IT8665E chips. IT8665E uses the exact same principle for accessing fan speeds as IT8688E and IT8686E, therefore this should work as expected.