### PR TITLE
fix #issues 163: Not Publishing CPU Temperature Readings in the version after 0.6.4

### DIFF
--- a/SMCAMDProcessor/SMCAMDProcessor.hpp
+++ b/SMCAMDProcessor/SMCAMDProcessor.hpp
@@ -9,6 +9,7 @@
 
 #include <AMDRyzenCPUPowerManagement.hpp>
 
+#undef EFIAPI   // must place here!
 #include <VirtualSMCSDK/kern_vsmcapi.hpp>
 #include <VirtualSMCSDK/AppleSmc.h>
 

--- a/SMCAMDProcessor/SMCAMDProcessor.hpp
+++ b/SMCAMDProcessor/SMCAMDProcessor.hpp
@@ -12,6 +12,7 @@
 #undef EFIAPI   // must place here!
 #include <VirtualSMCSDK/kern_vsmcapi.hpp>
 #include <VirtualSMCSDK/AppleSmc.h>
+#define EFIAPI
 
 class SMCAMDProcessor : public IOService {
     OSDeclareDefaultStructors(SMCAMDProcessor)


### PR DESCRIPTION
We can get the SMCKey info from the command "smcread -s". (smcread came from [VirtualSMC](https://github.com/acidanthera/VirtualSMC))

The version 0.6.4: It's OK!
[TC0E] type [sp78] 73703738 len [ 2] attr [80] -> 3610
[TC0F] type [sp78] 73703738 len [ 2] attr [80] -> 3610
[TC0J] type [sp78] 73703738 len [ 2] attr [80] -> 0000
[TC0P] type [sp78] 73703738 len [ 2] attr [80] -> 3610
[TC0T] type [sp78] 73703738 len [ 2] attr [80] -> 3610
[TC0p] type [sp78] 73703738 len [ 2] attr [80] -> 3610
[PCPR] type [?] 00000000 len [ 0] attr [00] -> NOT READABLE, code 89
[PSTR] type [?] 00000000 len [ 0] attr [00] -> NOT READABLE, code 89

After the version 0.6.4: It's not OK!
[E0CT] type [87ps] 38377073 len [ 2] attr [80] -> 3460
[F0CT] type [87ps] 38377073 len [ 2] attr [80] -> 3460
[J0CT] type [87ps] 38377073 len [ 2] attr [80] -> 0000
[P0CT] type [87ps] 38377073 len [ 2] attr [80] -> 3460
[T0CT] type [87ps] 38377073 len [ 2] attr [80] -> 3460
[p0CT] type [87ps] 38377073 len [ 2] attr [80] -> 3460
[RPCP] type [?] 00000000 len [ 0] attr [00] -> NOT READABLE, code 89
[RTSP] type [?] 00000000 len [ 0] attr [00] -> NOT READABLE, code 89

The iStat read the SMCKey value to show sensor info. The Key "TC0E" means CPU Temperature.  But now we can found the SMCKey "TC0E" was becoming "E0CT" ! They are in reverse order, So iStat cannot show the CPU Temperature again.

The "TC0E" was generated by the macro SMC_MAKE_IDENTIFIER. The order was controlled by the "EFIAPI" in SMC_MAKE_IDENTIFIER.

In the Lilu new version, there was a MacKernelSDK, and add the define "EFIAPI".
MacKernelSDK/Headers/pexpert/i386/efi.h:78:#define EFIAPI

So we must undef the EFIAPI after EFIAPI was defined && before the using by SMC_MAKE_IDENTIFIER.

